### PR TITLE
Fix keyboard shortcut focus issues by passing proper timestamps

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -4205,7 +4205,7 @@ class Dock(object):
                     wnck_ws.activate(0)
                     sleep(0.01)
 
-            window_control.activate(win)
+            window_control.activate_win(win)
 
     def activate_first_window(self, app):
         """ Active the specified apps's first window, changing workspace as

--- a/src/dock_applet.in
+++ b/src/dock_applet.in
@@ -579,15 +579,20 @@ def applet_shortcut_handler(keybinder, the_dock):
     if app is not None:
         start_app = app.is_running() is False
         if start_app:
-            app.start_app()
+            app.start_app(keybinder.current_timestamp)
         else:
-
-            # if the app only has a single window minimize or restore it
-            # otherwise scroll through all available windows
-            if app.get_num_windows() == 1:
-                the_dock.minimize_or_restore_windows(app)
+            if the_dock.win_switch_unity_style:
+                if app.is_active and app.get_num_windows() > 1:
+                    the_dock.do_window_selection(app)
+                else:
+                    the_dock.minimize_or_restore_windows(app, True)
             else:
-                the_dock.do_window_scroll(Gdk.ScrollDirection.DOWN, 0, app)
+                # if the app only has a single window minimize or restore it
+                # otherwise scroll through all available windows
+                if app.get_num_windows() == 1:
+                    the_dock.minimize_or_restore_windows(app, True)
+                else:
+                    the_dock.do_window_scroll(Gdk.ScrollDirection.DOWN, keybinder.current_timestamp, app)
 
 
 def applet_fill(applet):
@@ -720,6 +725,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         self.ignored_masks = self.get_mask_combinations(X.LockMask | X.Mod2Mask | X.Mod5Mask)
         self.map_modifiers()
         self.shortcuts = []
+        self.current_timestamp = 0
 
     def get_mask_combinations(self, mask):
         return [x for x in range(mask + 1) if not (x & ~mask)]
@@ -778,6 +784,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
                 if event.type == X.KeyPress and [event.detail, modifiers] in self.shortcuts:
                     # Track this shortcut to know which app to activate
                     self.current_shortcut = [event.detail, modifiers]
+                    self.current_timestamp = event.time
                     GLib.idle_add(self.idle)
                     self.display.allow_events(X.AsyncKeyboard, event.time)
                 else:

--- a/src/docked_app.in
+++ b/src/docked_app.in
@@ -1518,7 +1518,7 @@ class DockedApp(object):
 
         self.app_surface = surface
 
-    def start_app(self):
+    def start_app(self, timestamp=None):
         """Start the app or open a new window if it's already running
 
             Use Gio.DesktopAppinfo as it supports startup notfication
@@ -1560,7 +1560,10 @@ class DockedApp(object):
             alc = disp.get_app_launch_context()
 
         alc.set_desktop(-1)  # use default screen & desktop
-        alc.set_timestamp(Gtk.get_current_event_time())
+        if timestamp is not None:
+            alc.set_timestamp(timestamp)
+        else:
+            alc.set_timestamp(Gtk.get_current_event_time())
         alc.connect("launch-failed", self.launch_failed)
 
         # indicate we want startup notification


### PR DESCRIPTION
Applications launched via Super+# keyboard shortcuts sometimes don't get focus because start_app() used Gtk.get_current_event_time() which returned 0 when called from X11 KeyPress events instead of GTK events.

This change ensures applications launched via keyboard shortcuts get proper startup notification timestamps, allowing the window manager to focus them correctly instead of just blinking in the taskbar.