### PR TITLE
Add option to disable Super+N keyboard shortcuts

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -554,6 +554,8 @@ class Dock(object):
         self.pa_configs = []
         self.pa_on_all_ws = True
         self.dock_fixed_size = -1
+        self.keyboard_shortcuts = True
+        self.keybinder = None
         self.ns_new_app = False
         self.dds_done = False
         self.ns_app_removed = None
@@ -980,6 +982,8 @@ class Dock(object):
                 self.dock_fixed_size = xml_settings[18]
                 self.click_action = xml_settings[19]
                 self.theme = xml_settings[20]
+                if len(xml_settings) > 21:
+                    self.keyboard_shortcuts = xml_settings[21]
 
                 # now, immediately write the settings to dconf and back to the
                 # config file so the dock can access them
@@ -1017,6 +1021,7 @@ class Dock(object):
                 self.settings.set_int("dock-fixed-size", self.dock_fixed_size)
                 self.settings.set_int("click-action", self.click_action)
                 self.settings.set_int("theme", self.theme)
+                self.settings.set_boolean("keyboard-shortcuts", self.keyboard_shortcuts)
 
                 dock_xml.write_xml(self.xml_conf, pinned_apps, self.indicator,
                                    self.show_all_apps, self.multi_ind,
@@ -1034,7 +1039,8 @@ class Dock(object):
                                    self.pa_on_all_ws,
                                    self.dock_fixed_size,
                                    self.click_action,
-                                   self.theme)
+                                   self.theme,
+                                   self.keyboard_shortcuts)
 
                 return
 
@@ -1062,6 +1068,7 @@ class Dock(object):
         self.dock_fixed_size = self.settings.get_int("dock-fixed-size")
         self.click_action = self.settings.get_int("click-action")
         self.theme = self.settings.get_int("theme")
+        self.keyboard_shortcuts = self.settings.get_boolean("keyboard-shortcuts")
 
     def configs_to_settings(self):
         """ Convenience function to convert the current set of saved configs
@@ -1136,6 +1143,7 @@ class Dock(object):
             self.settings.set_int("dock-fixed-size", self.dock_fixed_size)
             self.settings.set_int("click-action", self.click_action)
             self.settings.set_int("theme", self.theme)
+            self.settings.set_boolean("keyboard-shortcuts", self.keyboard_shortcuts)
 
         dock_xml.write_xml(self.xml_conf, pinned_apps, self.indicator,
                            self.show_all_apps, self.multi_ind,
@@ -1154,7 +1162,8 @@ class Dock(object):
                            self.pa_on_all_ws,
                            self.dock_fixed_size,
                            self.click_action,
-                           self.theme)
+                           self.theme,
+                           self.keyboard_shortcuts)
 
     def read_app_match(self):
         """ Read an xml file which contains a list of apps which are difficult
@@ -1966,6 +1975,7 @@ class Dock(object):
             self.prefs_win.set_popup_delay(self.popup_delay)
             self.prefs_win.set_show_pinned_apps_on_all_ws(self.pa_on_all_ws)
             self.prefs_win.set_theme(self.theme)
+            self.prefs_win.set_keyboard_shortcuts(self.keyboard_shortcuts)
             if not build_gtk2 and not self.nice_sizing:
                 self.prefs_win.set_fixed_size(self.dock_fixed_size != -1, self.dock_fixed_size,
                                               self.panel_layout.upper() == "MUTINY")
@@ -2026,6 +2036,7 @@ class Dock(object):
            (self.popup_delay != self.prefs_win.get_popup_delay()) or \
            (self.pa_on_all_ws != self.prefs_win.get_show_pinned_apps_on_all_ws()) or \
            (self.theme != self.prefs_win.get_theme()) or \
+           (self.keyboard_shortcuts != self.prefs_win.get_keyboard_shortcuts()) or \
            fixed_size_changes:
 
             old_ind = self.indicator
@@ -2056,6 +2067,15 @@ class Dock(object):
             old_bg = self.active_bg
             self.active_bg = self.prefs_win.get_bg()
             self.theme = self.prefs_win.get_theme()
+
+            if self.keyboard_shortcuts != self.prefs_win.get_keyboard_shortcuts():
+                self.keyboard_shortcuts = self.prefs_win.get_keyboard_shortcuts()
+                if self.keybinder is not None:
+                    if self.keyboard_shortcuts:
+                        self.keybinder.regrab()
+                    else:
+                        self.keybinder.ungrab()
+
             # if we're changing to or from a Unity background we need
             # to reload docked app icons
             unity_bg_types = [docked_app_helpers.IconBgType.UNITY, docked_app_helpers.IconBgType.UNITY_FLAT]

--- a/src/dock_applet.in
+++ b/src/dock_applet.in
@@ -571,6 +571,9 @@ def applet_shortcut_handler(keybinder, the_dock):
     :param keybinder: the keybinder object with the keystring which was pressed e.g. "<Super>4"
     :param the_dock: the dock...
     """
+    if not the_dock.keyboard_shortcuts:
+        return
+
     # get the position in the dock of the app we need to activate
     if keybinder.current_shortcut in keybinder.shortcuts:
         app_no = keybinder.shortcuts.index(keybinder.current_shortcut)
@@ -679,10 +682,12 @@ def applet_fill(applet):
 
     # set up keyboard shortcuts used to activate apps in the dock
     keybinder = GlobalKeyBinding()
-    for shortcut in keyb_shortcuts:
-        keybinder.grab(shortcut)
     keybinder.connect("activate", applet_shortcut_handler, the_dock)
+    if the_dock.keyboard_shortcuts:
+        for shortcut in keyb_shortcuts:
+            keybinder.grab(shortcut)
     keybinder.start()
+    the_dock.keybinder = keybinder
 
     applet.set_background_widget(applet)  # hack for panel transparency
 
@@ -798,6 +803,19 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
     def ungrab(self):
         for shortcut in self.shortcuts:
             self.window.ungrab_key(shortcut[0], X.AnyModifier, self.window)
+        self.display.flush()
+
+    def regrab(self):
+        if not self.shortcuts:
+            for shortcut in keyb_shortcuts:
+                self.grab(shortcut)
+        else:
+            for shortcut in self.shortcuts:
+                catch = error.CatchError(error.BadAccess)
+                for ignored_mask in self.ignored_masks:
+                    mod = shortcut[1] | ignored_mask
+                    self.window.grab_key(shortcut[0], mod, True, X.GrabModeAsync, X.GrabModeAsync, onerror=catch)
+                self.display.flush()
 
 
 MatePanelApplet.Applet.factory_main("DockAppletFactory", True,

--- a/src/dock_prefs.in
+++ b/src/dock_prefs.in
@@ -410,6 +410,9 @@ class DockPrefsWindow(Gtk.Window):
 
         self.__cb_win_switch_unity_style = Gtk.CheckButton(label=_("Unity-style behaviour (always focus app on first click)"))
 
+        self.__cb_keyboard_shortcuts = Gtk.CheckButton(label=_("Enable keyboard shortcuts (Super+N) to activate apps"))
+        self.__cb_keyboard_shortcuts.set_tooltip_text(_("Enable Super+1 through Super+0 keyboard shortcuts to activate docked apps"))
+
         self.__notes_behaviour_tv = Gtk.TextView()
         self.__notes_behaviour_tv.set_wrap_mode(Gtk.WrapMode.WORD)
         self.__notes_behaviour_tv.set_editable(False)
@@ -434,6 +437,7 @@ class DockPrefsWindow(Gtk.Window):
                                          False, 4)
         self.__behaviour_vbox.pack_start(self.__cb_pan_act, False, False, 4)
         self.__behaviour_vbox.pack_start(self.__cb_win_switch_unity_style, False, False, 4)
+        self.__behaviour_vbox.pack_start(self.__cb_keyboard_shortcuts, False, False, 4)
         self.__behaviour_vbox.pack_start(self.__notes_behaviour_tv, False, False, 4)
 
         self.__frame_spc = create_frame(_("App spacing"))
@@ -1295,6 +1299,12 @@ class DockPrefsWindow(Gtk.Window):
         """
 
         self.__cb_win_switch_unity_style.set_active(win_switch_unity_style)
+
+    def get_keyboard_shortcuts(self):
+        return self.__cb_keyboard_shortcuts.get_active()
+
+    def set_keyboard_shortcuts(self, keyboard_shortcuts):
+        self.__cb_keyboard_shortcuts.set_active(keyboard_shortcuts)
 
     def set_fallback_bar_col(self, colrgb):
         """

--- a/src/dock_xml.in
+++ b/src/dock_xml.in
@@ -50,7 +50,7 @@ def write_xml(filename, desktop_files, light_ind, show_all_apps, multi_ind,
               panel_change_color, dock_panel_change_only, use_panel_act_list,
               active_icon_bg, fallback_bar_col, spacing, attention_type,
               popup_delay, saved_configs, pa_on_all_ws, dock_fixed_size,
-              click_action, theme):
+              click_action, theme, keyboard_shortcuts=True):
     """ Write the xml file using the specified information
 
     The xml file will be in e.g. the following format:
@@ -188,6 +188,8 @@ def write_xml(filename, desktop_files, light_ind, show_all_apps, multi_ind,
 
     theme_el = ET.Element("theme", id="%d" % theme)
 
+    kb_el = ET.Element("keyboard_shortcuts", enabled="%s" % keyboard_shortcuts)
+
     root.append(pa_el)
     root.append(ind_el)
     root.append(sa_el)
@@ -208,11 +210,12 @@ def write_xml(filename, desktop_files, light_ind, show_all_apps, multi_ind,
     root.append(dfs_el)
     root.append(ct_el)
     root.append(theme_el)
+    root.append(kb_el)
 
     try:
         ET.ElementTree(root).write(filename, xml_declaration=True)
-    except FileNotFoundError:
-        return False  # invalid file or path name
+    except (FileNotFoundError, PermissionError):
+        return False
 
     return True
 
@@ -399,13 +402,19 @@ def read_xml(filename):
     else:
         theme = 0
 
+    kb_el = root.find("keyboard_shortcuts")
+    if kb_el is not None:
+        keyboard_shortcuts = kb_el.get("enabled") == "True"
+    else:
+        keyboard_shortcuts = True
+
     return [True, df_list, light_ind, show_all, multi_ind,
             use_win_list, win_from_cur_ws_only, win_switch_unity_style,
             panel_change_color, dock_panel_change_only,
             use_panel_act_list, bg_type, fallback_bar_col,
             spacing, attention_type, popup_delay, saved_configs,
             pinned_apps_all_workspaces, dock_fixed_size, click_action,
-            theme]
+            theme, keyboard_shortcuts]
 
 
 def read_app_xml(filename):

--- a/src/org.mate.panel.applet.dock.gschema.xml
+++ b/src/org.mate.panel.applet.dock.gschema.xml
@@ -106,6 +106,11 @@
      <summary>Defines what to do when a running app's dock icon is clicked</summary>
      <description>0 = display the app's window list, 1 = show compiz window spread, 2 = minimize/restore all app's windows. Note: the use-win-list key is now deprecated.</description>
     </key>
+    <key type="b" name="keyboard-shortcuts">
+       <default>true</default>
+       <summary>Whether keyboard shortcuts (Super+N) are enabled</summary>
+       <description>Whether the Super+1 through Super+0 (and Super+Alt+1 through Super+Alt+0) keyboard shortcuts are enabled for activating docked apps</description>
+    </key>
     <key type="i" name="theme">
       <default>0</default>
       <summary>Specifies the theme used by the dock (e.g. Unity, Subway, Default).</summary>


### PR DESCRIPTION
Add a gsettings toggle and preferences checkbox to enable/disable the Super+1 through Super+0 keyboard shortcuts for activating docked apps. This allows users to reclaim those keys for other purposes.

Fixes #175

<img width="495" alt="image" src="https://github.com/user-attachments/assets/5ed592a1-ae55-4719-a0b1-1fd44d2cb5cc" />
