### PR TITLE
stop_drag_motion_timer(): NoneType object has no attribute drag_ended

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -4416,7 +4416,8 @@ class Dock(object):
         """  Stop the drag motion timer
         """
 
-        self.dm_timer.drag_ended = True
+        if self.dm_timer is not None:
+            self.dm_timer.drag_ended = True
 
     def start_da_timer(self, app):
         """


### PR DESCRIPTION
Fix: dock_applet.py crashed with AttributeError in stop_drag_motion_timer(): 'NoneType' object has no attribute 'drag_ended'.