### PR TITLE
show_or_hide_app_icons(): NoneType object has no attribute get_name

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -3106,7 +3106,6 @@ class Dock(object):
                         if not app.is_visible():
                             app.show_icon()
             else:
-                ws_name = cur_ws.get_name()
                 for app in self.app_list:
                     if not app.is_pinned:
                         pinned_ws = self.app_is_pinned_to_workspace(app)


### PR DESCRIPTION
Fix: remove an unused get_name call on a possibly missing active workspace.